### PR TITLE
Added an option that makes an option vscode_cmakekit_generator:vscode_folder

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -5,11 +5,13 @@ from conans.client.build.cmake_flags import CMakeDefinitionsBuilder, get_generat
 from conans import ConanFile
 from conans.util.env_reader import get_env
 from conans.model.conan_file import get_env_context_manager
+from conans.util.files import save
+from conans.errors import ConanInvalidConfiguration
 
 
 def _cmake_escape_backslash(inp: str):
     """
-    Escapes backslashes for cmake. Basically it replaces any \ with \\
+    Escapes backslashes for cmake. Basically it replaces any \\ with \\\\
     :param inp: Input string
     :return: Input string with backslashes escaped for cmake
     """
@@ -29,18 +31,20 @@ class vscode_cmakekit(Generator):
         :return: List of lines to print into a cmake file
         """
         old_env = dict(os.environ)
-        
+
         with get_env_context_manager(self.conanfile):
             ret = ["\t\t\"environmentVariables\": {"]
 
             for name, value in self.conanfile.env.items():
                 if isinstance(value, list):
                     if name in old_env:
-                        value = str(get_env(name)).replace(old_env[name], "${{env:{name}}}").format(name=name)
+                        value = str(get_env(name)).replace(
+                            old_env[name], "${{env:{name}}}").format(name=name)
                     else:
                         value = str(value)
                 value = _cmake_escape_backslash(value)
-                ret.append("\t\t\t\"{name}\": \"{value}\"".format(name=name, value=value))
+                ret.append("\t\t\t\"{name}\": \"{value}\"".format(
+                    name=name, value=value))
             ret[1:-1] = [line + "," for line in ret[1:-1]]
             return ret
 
@@ -55,15 +59,17 @@ class vscode_cmakekit(Generator):
             build_type = self.conanfile.settings.get_safe("build_type")
             generator = get_generator(self.conanfile.settings)
             self.conanfile.install_folder = ""
-            def_builder = CMakeDefinitionsBuilder(self.conanfile, generator=generator, forced_build_type=build_type)
+            def_builder = CMakeDefinitionsBuilder(
+                self.conanfile, generator=generator, forced_build_type=build_type)
             definitions = def_builder.get_definitions()
 
             for name, value in definitions.items():
-                ret.append("\t\t\t\"{name}\": \"{value}\",".format(name=name, value=value))
+                ret.append("\t\t\t\"{name}\": \"{value}\",".format(
+                    name=name, value=value))
 
-            deps=[]
-            
-            for dep_name, dep_cpp_info in self.deps_build_info.dependencies:
+            deps = []
+
+            for _, dep_cpp_info in self.deps_build_info.dependencies:
                 deps.append("\t\t\t\t\t" + DepsCppCmake(dep_cpp_info).rootpath)
             deps[:-1] = [line + "," for line in deps[:-1]]
             ret.append("\t\t\t\"CMAKE_PREFIX_PATH\": [")
@@ -83,7 +89,7 @@ class vscode_cmakekit(Generator):
     def content(self):
         """ Content of the output file. """
         # environment and definitions will only be set if cmake has not been invoked by conan
-        lines=["["]
+        lines = ["["]
         lines.append("\t{")
         lines.append("\t\t\"name\": \"conan-generated\",")
         lines.extend(self._get_cmake_environment_setters())
@@ -92,16 +98,33 @@ class vscode_cmakekit(Generator):
         lines.append("\t\t}")
         lines.append("\t}")
         lines.append("]")
-        return os.linesep.join(lines) + "\n"
+        result = os.linesep.join(lines) + "\n"
+        savepath = os.path.join(
+            os.environ['vscode_output_folder'], self.filename)
+        save(savepath, result)
+        self.conanfile.output.info(
+            "Generator vscode_cmakekit saved cmake-kits.json to: %s" % savepath)
+        return result
 
 
 class VSCodeCmakeKitGeneratorPackage(ConanFile):
     name = 'vscode_cmakekit_generator'
     version = '0.2'
-    description = "A generator for conan that can be used to build conan packages " \
-                  "by invoking cmake instead of conan build"
+    description = "A generator for conan that can be used to build conan packages "
+    "by invoking cmake instead of conan build"
     url = 'https://github.com/pepe82sh/ConanCmakeToolchainGenerator'
     license = 'MIT'
+    options = {'vscode_folder': 'ANY'}
+
+    def configure(self):
+        """ Configure the vscode_folder in an environment variable to be used in the generator step. """
+        vscode_folder = self.options.vscode_folder.value
+        if vscode_folder is None or os.path.basename(vscode_folder) != ".vscode":
+            raise ConanInvalidConfiguration(
+                "The given option for vscode_cmakekit_generator:vscode_folder is not an existing .vscode folder. Found value: %s" % vscode_folder)
+
+        # folder is valid, set it to the environment to use it during the save functionality
+        os.environ['vscode_output_folder'] = vscode_folder
 
     def build(self):
         pass

--- a/conanfile.py
+++ b/conanfile.py
@@ -109,7 +109,7 @@ class vscode_cmakekit(Generator):
 
 class VSCodeCmakeKitGeneratorPackage(ConanFile):
     name = 'vscode_cmakekit_generator'
-    version = '0.2'
+    version = '0.3'
     description = "A generator for conan that can be used to build conan packages "
     "by invoking cmake instead of conan build"
     url = 'https://github.com/pepe82sh/ConanCmakeToolchainGenerator'


### PR DESCRIPTION
Added an option that makes an option vscode_cmakekit_generator:vscode_folder mandatory when using this package.

Given this folder, the cmake-kits.json file is saved to a .vscode folder.
Validates on the basename in the configure step, which must be .vscode.

os.environ was used to pass the parameter to the Generator, because self.conanfile.options appears to be empty in the Generator content step.